### PR TITLE
fix: xAdd/substract/divide/multiply also work with floatarray

### DIFF
--- a/src/x/__tests__/xAdd.test.js
+++ b/src/x/__tests__/xAdd.test.js
@@ -11,4 +11,10 @@ describe('xAdd', function () {
     let array1 = [10, 11, 12, 13, 14];
     expect(xAdd(array1, 5)).toStrictEqual([15, 16, 17, 18, 19]);
   });
+
+  it('test xAdd of array and floatarray', () => {
+    let array1 = [10, 11, 12, 13, 14];
+    let array2 = new Float32Array([5, 4, 3, 2, 1]);
+    expect(xAdd(array1, array2)).toStrictEqual([15, 15, 15, 15, 15]);
+  });
 });

--- a/src/x/__tests__/xDivide.test.js
+++ b/src/x/__tests__/xDivide.test.js
@@ -7,6 +7,11 @@ describe('divide', function () {
     expect(xDivide(array1, array2)).toStrictEqual([5, 5, 5, 5, 5]);
   });
 
+  it('test divide of Array and FloatArray', () => {
+    let array1 = [10, 15, 20, 25, 30];
+    let array2 = new Float64Array([2, 3, 4, 5, 6]);
+    expect(xDivide(array1, array2)).toStrictEqual([5, 5, 5, 5, 5]);
+  });
   it('test mul of 2 a constant', () => {
     let array1 = [10, 15, 20, 25, 30];
     expect(xDivide(array1, 5)).toStrictEqual([2, 3, 4, 5, 6]);

--- a/src/x/__tests__/xMultiply.test.js
+++ b/src/x/__tests__/xMultiply.test.js
@@ -13,6 +13,18 @@ describe('xMultiply', function () {
     ]);
   });
 
+  it('test mul of array and floatarray', () => {
+    let array1 = [10, 11, 12, 13, 14];
+    let array2 = new Float64Array([5, 4, 3, 2, 1]);
+    expect(Array.from(xMultiply(array1, array2))).toStrictEqual([
+      50,
+      44,
+      36,
+      26,
+      14,
+    ]);
+  });
+
   it('test mul of 2 a constant', () => {
     let array1 = [10, 11, 12, 13, 14];
     expect(Array.from(xMultiply(array1, 5))).toStrictEqual([

--- a/src/x/__tests__/xSubtract.test.js
+++ b/src/x/__tests__/xSubtract.test.js
@@ -11,4 +11,10 @@ describe('xSubtract', function () {
     let array1 = [10, 11, 12, 13, 14];
     expect(xSubtract(array1, 5)).toStrictEqual([5, 6, 7, 8, 9]);
   });
+
+  it('test xSubtract of array and floatarray', () => {
+    let array1 = new Float32Array([10, 11, 12, 13, 14]);
+    let array2 = [5, 4, 3, 2, 1];
+    expect(xSubtract(array1, array2)).toStrictEqual([5, 7, 9, 11, 13]);
+  });
 });

--- a/src/x/xAdd.js
+++ b/src/x/xAdd.js
@@ -1,4 +1,4 @@
-/**
+import isAnyArray from 'is-any-array';
 
 /**
  * This function xAdd the first array by the second array or a constant value to each element of the first array
@@ -9,7 +9,7 @@
 export function xAdd(array1, array2) {
   let isConstant = false;
   let constant;
-  if (Array.isArray(array2)) {
+  if (isAnyArray(array2)) {
     if (array1.length !== array2.length) {
       throw new Error('sub: size of array1 and array2 must be identical');
     }

--- a/src/x/xDivide.js
+++ b/src/x/xDivide.js
@@ -1,4 +1,4 @@
-/**
+import isAnyArray from 'is-any-array';
 
 /**
  * This function divide the first array by the second array or a constant value to each element of the first array
@@ -9,7 +9,7 @@
 export function xDivide(array1, array2) {
   let isConstant = false;
   let constant;
-  if (Array.isArray(array2)) {
+  if (isAnyArray(array2)) {
     if (array1.length !== array2.length) {
       throw new Error('sub: size of array1 and array2 must be identical');
     }

--- a/src/x/xMultiply.js
+++ b/src/x/xMultiply.js
@@ -1,5 +1,4 @@
-/**
-
+import isAnyArray from 'is-any-array';
 /**
  * This function xMultiply the first array by the second array or a constant value to each element of the first array
  * @param {Array} array1 - the array that will be rotated
@@ -9,7 +8,7 @@
 export function xMultiply(array1, array2) {
   let isConstant = false;
   let constant;
-  if (Array.isArray(array2)) {
+  if (isAnyArray(array2)) {
     if (array1.length !== array2.length) {
       throw new Error('sub: size of array1 and array2 must be identical');
     }

--- a/src/x/xSubtract.js
+++ b/src/x/xSubtract.js
@@ -1,3 +1,4 @@
+import isAnyArray from 'is-any-array';
 /**
  * This function xSubtract the first array by the second array or a constant value from each element of the first array
  * @param {Array} array1 - the array that will be rotated
@@ -7,7 +8,7 @@
 export function xSubtract(array1, array2) {
   let isConstant = false;
   let constant;
-  if (Array.isArray(array2)) {
+  if (isAnyArray(array2)) {
     if (array1.length !== array2.length) {
       throw new Error('sub: size of array1 and array2 must be identical');
     }


### PR DESCRIPTION
fixed the issue that is due to 

```javascript
a = new Float32Array([2,2])
Array.isArray(a)
>false
```

i also noticed that sometimes the output is `Array` (e.g., `xSubstract`) and in other cases `FloatArray` (e.g., `xMultiply`) should we make it more consistent and use `Float64Array` for all? 
