### PR TITLE
feat: add xCostMatrix function

### DIFF
--- a/src/x/__tests__/xCostMatrix.test.ts
+++ b/src/x/__tests__/xCostMatrix.test.ts
@@ -1,5 +1,6 @@
-import { xCostMatrix } from '../xCostMatrix';
 import { toMatchCloseTo } from 'jest-matcher-deep-close-to';
+
+import { xCostMatrix } from '../xCostMatrix';
 
 expect.extend({ toMatchCloseTo });
 
@@ -8,7 +9,6 @@ describe('xCostMatrix', () => {
   const array2 = [5, 4, 3, 2, 1];
   it('default function', () => {
     const result = xCostMatrix(array1, array2);
-    console.log(result.to2DArray());
     expect(result.to2DArray()).toMatchCloseTo([
       [4, 3, 2, 1, 0],
       [3, 2, 1, 0, 1],
@@ -19,7 +19,6 @@ describe('xCostMatrix', () => {
   });
   it('diff function', () => {
     const result = xCostMatrix(array1, array2, { fct: (a, b) => a - b });
-    console.log(result.to2DArray());
     expect(result.to2DArray()).toMatchCloseTo([
       [-4, -3, -2, -1, 0],
       [-3, -2, -1, 0, 1],

--- a/src/x/__tests__/xCostMatrix.test.ts
+++ b/src/x/__tests__/xCostMatrix.test.ts
@@ -1,0 +1,31 @@
+import { xCostMatrix } from '../xCostMatrix';
+import { toMatchCloseTo } from 'jest-matcher-deep-close-to';
+
+expect.extend({ toMatchCloseTo });
+
+describe('xCostMatrix', () => {
+  const array1 = [1, 2, 3, 4, 5];
+  const array2 = [5, 4, 3, 2, 1];
+  it('default function', () => {
+    const result = xCostMatrix(array1, array2);
+    console.log(result.to2DArray());
+    expect(result.to2DArray()).toMatchCloseTo([
+      [4, 3, 2, 1, 0],
+      [3, 2, 1, 0, 1],
+      [2, 1, 0, 1, 2],
+      [1, 0, 1, 2, 3],
+      [0, 1, 2, 3, 4],
+    ]);
+  });
+  it('diff function', () => {
+    const result = xCostMatrix(array1, array2, { fct: (a, b) => a - b });
+    console.log(result.to2DArray());
+    expect(result.to2DArray()).toMatchCloseTo([
+      [-4, -3, -2, -1, 0],
+      [-3, -2, -1, 0, 1],
+      [-2, -1, 0, 1, 2],
+      [-1, 0, 1, 2, 3],
+      [0, 1, 2, 3, 4],
+    ]);
+  });
+});

--- a/src/x/xCostMatrix.ts
+++ b/src/x/xCostMatrix.ts
@@ -11,7 +11,8 @@ interface XCostMatrixOptions {
 }
 
 /**
- * Generate a cost matrix from two set of values using the function passed.
+ * Generate a cost matrix from two set of values using the function passed. by default it
+ * generate the cost matrix of absolute value of diferences.
  * @param rowsArray - Array of values that will represent the rows of the cost matrix.
  * @param columnsArray - Array of values that will represent the columns of the cost matrix.
  * @returns - A matrix instance with dimensions rowsArray.length x columnsArray.length

--- a/src/x/xCostMatrix.ts
+++ b/src/x/xCostMatrix.ts
@@ -4,23 +4,32 @@ import { Matrix } from 'ml-matrix';
 const absDiff = (a: number, b: number) => Math.abs(a - b);
 
 interface XCostMatrixOptions {
+  /**
+   * function to generate the elements of a cost matrix. The first argunment come from rowsArray input and the second argument come from columnsArray input.
+   */
   fct?: (a: number, b: number) => number;
 }
 
+/**
+ * Generate a cost matrix from two set of values using the function passed.
+ * @param rowsArray - Array of values that will represent the rows of the cost matrix.
+ * @param columnsArray - Array of values that will represent the columns of the cost matrix.
+ * @returns - A matrix instance with dimensions rowsArray.length x columnsArray.length
+ */
 export function xCostMatrix(
-  array1: DoubleArray,
-  array2: DoubleArray,
+  rowsArray: DoubleArray,
+  columnsArray: DoubleArray,
   options: XCostMatrixOptions = {},
 ) {
   const { fct = absDiff } = options;
 
-  const nbRows = array1.length;
-  const nbColumns = array2.length;
+  const nbRows = rowsArray.length;
+  const nbColumns = columnsArray.length;
 
   const result = new Matrix(nbRows, nbColumns);
   for (let r = 0; r < nbRows; r++) {
     for (let c = 0; c < nbColumns; c++) {
-      result.set(r, c, fct(array1[r], array2[c]));
+      result.set(r, c, fct(rowsArray[r], columnsArray[c]));
     }
   }
   return result;

--- a/src/x/xCostMatrix.ts
+++ b/src/x/xCostMatrix.ts
@@ -1,17 +1,16 @@
 import { DoubleArray } from 'cheminfo-types';
-import Matrix from 'ml-matrix';
-import { xSubtract } from './xSubtract';
+import { Matrix } from 'ml-matrix';
 
 const absDiff = (a: number, b: number) => Math.abs(a - b);
 
-interface xCostMatrixOptions {
+interface XCostMatrixOptions {
   fct?: (a: number, b: number) => number;
 }
 
 export function xCostMatrix(
   array1: DoubleArray,
   array2: DoubleArray,
-  options: xCostMatrixOptions = {},
+  options: XCostMatrixOptions = {},
 ) {
   const { fct = absDiff } = options;
 

--- a/src/x/xCostMatrix.ts
+++ b/src/x/xCostMatrix.ts
@@ -1,0 +1,28 @@
+import { DoubleArray } from 'cheminfo-types';
+import Matrix from 'ml-matrix';
+import { xSubtract } from './xSubtract';
+
+const absDiff = (a: number, b: number) => Math.abs(a - b);
+
+interface xCostMatrixOptions {
+  fct?: (a: number, b: number) => number;
+}
+
+export function xCostMatrix(
+  array1: DoubleArray,
+  array2: DoubleArray,
+  options: xCostMatrixOptions = {},
+) {
+  const { fct = absDiff } = options;
+
+  const nbRows = array1.length;
+  const nbColumns = array2.length;
+
+  const result = new Matrix(nbRows, nbColumns);
+  for (let r = 0; r < nbRows; r++) {
+    for (let c = 0; c < nbColumns; c++) {
+      result.set(r, c, fct(array1[r], array2[c]));
+    }
+  }
+  return result;
+}


### PR DESCRIPTION
I am adding the xCostMatrix function to generate a cost matrix function passing the function to be applied to the couples of elements of input arrays.

the use would be:
```js
import { xcostMatrix } from 'ml-spectra-processing';

const diff = xCostMatrix(experimental, predicted, { 
   fct: (a, b) => Math.abs(a - b)
});
```

by default the function used by `xCostMatrix` is the absolute value of the difference