### PR TITLE
 improve speed Whittaker smoother

### DIFF
--- a/src/matrix/__tests__/matrixCholeskySolver.test.ts
+++ b/src/matrix/__tests__/matrixCholeskySolver.test.ts
@@ -18,7 +18,7 @@ test('solve a least square system', () => {
 
   const lambda = 20;
   const dimension = x.length;
-  const upperTriangularNonZeros = createSystemMatrix(dimension, lambda);
+  const { upperTriangularNonZeros } = createSystemMatrix(dimension, lambda);
 
   const weighted = addWeights(upperTriangularNonZeros, y, weights);
 

--- a/src/matrix/__tests__/matrixCholeskySolver.test.ts
+++ b/src/matrix/__tests__/matrixCholeskySolver.test.ts
@@ -54,7 +54,7 @@ test('solve a least square system', () => {
 
   expect(cho3).not.toBeNull();
 
-  const smoothed3 = cho2(weighted2.rightHandSide);
+  const smoothed3 = cho3(weighted2.rightHandSide);
 
   expect(smoothed3[50]).toStrictEqual(smoothed3[50]);
 });

--- a/src/matrix/matrixCholeskySolver.ts
+++ b/src/matrix/matrixCholeskySolver.ts
@@ -38,34 +38,37 @@ export function matrixCholeskySolver(
   permutationEncoded?: NumberArray,
 ): ((b: NumberArray) => NumberArray) | null {
   if (permutationEncoded) {
-    const pinv = new Array(dimension);
+    const pinv = new Int32Array(dimension);
     for (let k = 0; k < dimension; k++) {
       pinv[permutationEncoded[k]] = k;
     }
+    // Build a permuted copy (kept as plain arrays for compatibility)
     const mt: NumberArray[] = new Array(nonZerosArray.length);
     for (let a = 0; a < nonZerosArray.length; ++a) {
       const [r, c, value] = nonZerosArray[a];
-      const [ar, ac] = [pinv[r], pinv[c]];
+      const ar = pinv[r];
+      const ac = pinv[c];
       mt[a] = ac < ar ? [ac, ar, value] : [ar, ac, value];
     }
     nonZerosArray = mt;
   } else {
-    permutationEncoded = [];
+    // use a typed identity permutation
+    const p = new Int32Array(dimension);
     for (let i = 0; i < dimension; ++i) {
-      permutationEncoded[i] = i;
+      p[i] = i;
     }
+    permutationEncoded = p;
   }
 
-  const ap: NumberArray = new Array(dimension + 1);
-  const ai = new Array(nonZerosArray.length);
-  const ax = new Array(nonZerosArray.length);
+  const nnz = nonZerosArray.length;
+  const ap = new Int32Array(dimension + 1);
+  const ai = new Int32Array(nnz);
+  const ax = new Float64Array(nnz);
 
-  const lnz = [];
-  for (let i = 0; i < dimension; ++i) {
-    lnz[i] = 0;
-  }
-  for (const a of nonZerosArray) {
-    lnz[a[1]]++;
+  const lnz = new Int32Array(dimension);
+  for (let idx = 0; idx < nnz; idx++) {
+    const col = nonZerosArray[idx][1];
+    lnz[col]++;
   }
 
   ap[0] = 0;
@@ -73,12 +76,9 @@ export function matrixCholeskySolver(
     ap[i + 1] = ap[i] + lnz[i];
   }
 
-  const colOffset = [];
-  for (let a = 0; a < dimension; ++a) {
-    colOffset[a] = 0;
-  }
-
-  for (const e of nonZerosArray) {
+  const colOffset = new Int32Array(dimension);
+  for (let idx = 0; idx < nnz; idx++) {
+    const e = nonZerosArray[idx];
     const col = e[1];
     const adr = ap[col] + colOffset[col];
     ai[adr] = e[0];
@@ -86,20 +86,21 @@ export function matrixCholeskySolver(
     colOffset[col]++;
   }
 
-  const d = new Array(dimension);
-  const y = new Array(dimension);
-  const lp = new Array(dimension + 1);
-  const parent = new Array(dimension);
-  const lnzArray = new Array(dimension);
-  const flag = new Array(dimension);
-  const pattern = new Array(dimension);
-  const bp1 = new Array(dimension);
-  const x = new Array(dimension);
+  const d = new Float64Array(dimension);
+  const y = new Float64Array(dimension);
+  const lp = new Int32Array(dimension + 1);
+  const parent = new Int32Array(dimension);
+  const lnzArray = new Int32Array(dimension);
+  const flag = new Int32Array(dimension);
+  const pattern = new Int32Array(dimension);
+  const bp1 = new Float64Array(dimension);
+  const x = new Float64Array(dimension);
 
   ldlSymbolic(dimension, ap, ai, lp, parent, lnzArray, flag);
 
-  const lx = new Array(lp[dimension]);
-  const li = new Array(lp[dimension]);
+  const nz = lp[dimension];
+  const lx = new Float64Array(nz);
+  const li = new Int32Array(nz);
 
   const result = ldlNumeric(
     dimension,
@@ -140,23 +141,24 @@ function ldlSymbolic(
   lnz: NumberArray,
   flag: NumberArray,
 ): void {
+  const apLoc = ap as Int32Array;
+  const aiLoc = ai as Int32Array;
+  const parentLoc = parent as Int32Array;
+  const lnzLoc = lnz as Int32Array;
+  const flagLoc = flag as Int32Array;
   for (let k = 0; k < dimension; k++) {
-    parent[k] = -1;
-    flag[k] = k;
-    lnz[k] = 0;
+    parentLoc[k] = -1;
+    flagLoc[k] = k;
+    lnzLoc[k] = 0;
     const kk = k;
-    const p2 = ap[kk + 1];
-    for (
-      let permutationEncoded = ap[kk];
-      permutationEncoded < p2;
-      permutationEncoded++
-    ) {
-      let i = ai[permutationEncoded];
+    const p2 = apLoc[kk + 1];
+    for (let p = apLoc[kk]; p < p2; p++) {
+      let i = aiLoc[p];
       if (i < k) {
-        for (; flag[i] !== k; i = parent[i]) {
-          if (parent[i] === -1) parent[i] = k;
-          lnz[i]++;
-          flag[i] = k;
+        for (; flagLoc[i] !== k; i = parentLoc[i]) {
+          if (parentLoc[i] === -1) parentLoc[i] = k;
+          lnzLoc[i]++;
+          flagLoc[i] = k;
         }
       }
     }
@@ -182,51 +184,57 @@ function ldlNumeric(
   pattern: NumberArray,
   flag: NumberArray,
 ): number {
-  let yi, lKi;
-  let i, k, permutationEncoded, kk, p2, len, top;
-  for (k = 0; k < dimension; k++) {
-    y[k] = 0;
-    top = dimension;
-    flag[k] = k;
-    lnz[k] = 0;
-    kk = k;
-    p2 = ap[kk + 1];
-    for (
-      permutationEncoded = ap[kk];
-      permutationEncoded < p2;
-      permutationEncoded++
-    ) {
-      i = ai[permutationEncoded];
+  const apLoc = ap as Int32Array;
+  const aiLoc = ai as Int32Array;
+  const axLoc = ax as Float64Array;
+  const lpLoc = lp as Int32Array;
+  const parentLoc = parent as Int32Array;
+  const lnzLoc = lnz as Int32Array;
+  const liLoc = li as Int32Array;
+  const lxLoc = lx as Float64Array;
+  const dLoc = d as Float64Array;
+  const yLoc = y as Float64Array;
+  const patternLoc = pattern as Int32Array;
+  const flagLoc = flag as Int32Array;
+
+  let yi: number, lKi: number;
+  for (let k = 0; k < dimension; k++) {
+    yLoc[k] = 0;
+    let top = dimension;
+    flagLoc[k] = k;
+    lnzLoc[k] = 0;
+    const kk = k;
+    const p2col = apLoc[kk + 1];
+    for (let p = apLoc[kk]; p < p2col; p++) {
+      let i = aiLoc[p];
       if (i <= k) {
-        y[i] += ax[permutationEncoded];
-        for (len = 0; flag[i] !== k; i = parent[i]) {
-          pattern[len++] = i;
-          flag[i] = k;
+        yLoc[i] += axLoc[p];
+        let len = 0;
+        for (; flagLoc[i] !== k; i = parentLoc[i]) {
+          patternLoc[len++] = i;
+          flagLoc[i] = k;
         }
-        while (len > 0) pattern[--top] = pattern[--len];
+        while (len > 0) patternLoc[--top] = patternLoc[--len];
       }
     }
-    d[k] = y[k];
-    y[k] = 0;
+    dLoc[k] = yLoc[k];
+    yLoc[k] = 0;
     for (; top < dimension; top++) {
-      i = pattern[top];
-      yi = y[i];
-      y[i] = 0;
-      p2 = lp[i] + lnz[i];
-      for (
-        permutationEncoded = lp[i];
-        permutationEncoded < p2;
-        permutationEncoded++
-      ) {
-        y[li[permutationEncoded]] -= lx[permutationEncoded] * yi;
+      const i = patternLoc[top];
+      yi = yLoc[i];
+      yLoc[i] = 0;
+      const p2 = lpLoc[i] + lnzLoc[i];
+      let p;
+      for (p = lpLoc[i]; p < p2; p++) {
+        yLoc[liLoc[p]] -= lxLoc[p] * yi;
       }
-      lKi = yi / d[i];
-      d[k] -= lKi * yi;
-      li[permutationEncoded] = k;
-      lx[permutationEncoded] = lKi;
-      lnz[i]++;
+      lKi = yi / dLoc[i];
+      dLoc[k] -= lKi * yi;
+      liLoc[p] = k;
+      lxLoc[p] = lKi;
+      lnzLoc[i]++;
     }
-    if (d[k] === 0) return k;
+    if (dLoc[k] === 0) return k;
   }
   return dimension;
 }
@@ -238,22 +246,23 @@ function ldlLsolve(
   li: NumberArray,
   lx: NumberArray,
 ): void {
-  let j, permutationEncoded, p2;
-  for (j = 0; j < dimension; j++) {
-    p2 = lp[j + 1];
-    for (
-      permutationEncoded = lp[j];
-      permutationEncoded < p2;
-      permutationEncoded++
-    ) {
-      x[li[permutationEncoded]] -= lx[permutationEncoded] * x[j];
+  const lpLoc = lp as Int32Array;
+  const liLoc = li as Int32Array;
+  const lxLoc = lx as Float64Array;
+  const xLoc = x as Float64Array;
+  for (let j = 0; j < dimension; j++) {
+    const p2 = lpLoc[j + 1];
+    for (let p = lpLoc[j]; p < p2; p++) {
+      xLoc[liLoc[p]] -= lxLoc[p] * xLoc[j];
     }
   }
 }
 
 function ldlDsolve(dimension: number, x: NumberArray, d: NumberArray): void {
+  const xLoc = x as Float64Array;
+  const dLoc = d as Float64Array;
   for (let j = 0; j < dimension; j++) {
-    x[j] /= d[j];
+    xLoc[j] /= dLoc[j];
   }
 }
 
@@ -264,15 +273,14 @@ function ldlLTsolve(
   li: NumberArray,
   lx: NumberArray,
 ): void {
-  let j, permutationEncoded, p2;
-  for (j = dimension - 1; j >= 0; j--) {
-    p2 = lp[j + 1];
-    for (
-      permutationEncoded = lp[j];
-      permutationEncoded < p2;
-      permutationEncoded++
-    ) {
-      x[j] -= lx[permutationEncoded] * x[li[permutationEncoded]];
+  const lpLoc = lp as Int32Array;
+  const liLoc = li as Int32Array;
+  const lxLoc = lx as Float64Array;
+  const xLoc = x as Float64Array;
+  for (let j = dimension - 1; j >= 0; j--) {
+    const p2 = lpLoc[j + 1];
+    for (let p = lpLoc[j]; p < p2; p++) {
+      xLoc[j] -= lxLoc[p] * xLoc[liLoc[p]];
     }
   }
 }
@@ -283,9 +291,11 @@ function ldlPerm(
   b: NumberArray,
   permutationEncoded: NumberArray,
 ): void {
-  let j;
-  for (j = 0; j < dimension; j++) {
-    x[j] = b[permutationEncoded[j]];
+  const perm = permutationEncoded as Int32Array;
+  const xLoc = x as Float64Array;
+  const bLoc = b as Float64Array;
+  for (let j = 0; j < dimension; j++) {
+    xLoc[j] = bLoc[perm[j]];
   }
 }
 
@@ -295,8 +305,10 @@ function ldlPermt(
   b: NumberArray,
   permutationEncoded: NumberArray,
 ): void {
-  let j;
-  for (j = 0; j < dimension; j++) {
-    x[permutationEncoded[j]] = b[j];
+  const perm = permutationEncoded as Int32Array;
+  const xLoc = x as Float64Array;
+  const bLoc = b as Float64Array;
+  for (let j = 0; j < dimension; j++) {
+    xLoc[perm[j]] = bLoc[j];
   }
 }

--- a/src/utils/createSystemMatrix.ts
+++ b/src/utils/createSystemMatrix.ts
@@ -1,3 +1,9 @@
+import { matrixCuthillMckee } from '../matrix/matrixCuthillMckee.ts';
+
+export interface SystemMatrix {
+  upperTriangularNonZeros: number[][];
+  permutationEncodedArray: Float64Array;
+}
 /**
  * Generates a lower triangular non-zeros of the first order smoother matrix (lambda D'D) where D is the derivate of the identity matrix
  * this function in combination with addWeights function can obtain (Q = W + lambda D'D) a penalized least square of Whittaker smoother,
@@ -12,7 +18,7 @@
 export function createSystemMatrix(
   dimension: number,
   lambda: number,
-): number[][] {
+): SystemMatrix {
   const upperTriangularNonZeros: number[][] = [];
   const last = dimension - 1;
   for (let i = 0; i < last; i++) {
@@ -20,5 +26,9 @@ export function createSystemMatrix(
   }
   upperTriangularNonZeros[0][2] = lambda;
   upperTriangularNonZeros.push([last, last, lambda]);
-  return upperTriangularNonZeros;
+  const permutationEncodedArray = matrixCuthillMckee(
+    upperTriangularNonZeros,
+    dimension,
+  );
+  return { upperTriangularNonZeros, permutationEncodedArray };
 }

--- a/src/x/__tests__/xWhittakerSmoother.test.ts
+++ b/src/x/__tests__/xWhittakerSmoother.test.ts
@@ -13,6 +13,24 @@ test('two peaks with sine baseline', () => {
   const smooth = xWhittakerSmoother(y, {
     lambda: 20,
     maxIterations: 100,
+    algorithm: 'cholesky',
+  });
+
+  expect(smooth[50]).toBeLessThan(0.2);
+  expect(smooth[50]).toBeGreaterThan(-0.2);
+});
+
+test('two peaks with sine baseline by thoma method', () => {
+  const x = xSequentialFillFromTo({ from: 0, to: Math.PI, size: 101 });
+  const noise = x.map(() => Math.random() * 0.1 - 0.05);
+  const y = x.map((value, index) => Math.cos(value) + 2 * noise[index]);
+
+  y[50] = 0.9; // add outliers
+
+  const smooth = xWhittakerSmoother(y, {
+    lambda: 20,
+    algorithm: 'thomas',
+    maxIterations: 100,
   });
 
   expect(smooth[50]).toBeLessThan(0.2);

--- a/src/x/xWhittakerSmoother.ts
+++ b/src/x/xWhittakerSmoother.ts
@@ -35,7 +35,38 @@ export interface XWhittakerSmootherOptions extends CalculateAdaptiveWeightsOptio
    * @default 0.5
    */
   learningRate?: number;
+  /**
+   * Solver algorithm to use for the smoothing routine.
+   * - `'cholesky'` — build the full (symmetric) system and solve using a
+   *   Cholesky decomposition. Generally more robust for small/medium arrays
+   *   and when a matrix factorization is acceptable.
+   * - `'thomas'` — use a tridiagonal formulation and solve with the Thomas
+   *   algorithm (specialised tridiagonal solver). Lower memory usage and
+   *   faster for large inputs when the system is tridiagonal.
+   *
+   * Default: `'cholesky'`.
+   */
+  algorithm?: 'cholesky' | 'thomas';
 }
+
+export function xWhittakerSmoother(
+  yData: NumberArray,
+  options: XWhittakerSmootherOptions = {},
+) {
+  const { algorithm = 'cholesky', ...restOptions } = options;
+
+  if (algorithm === 'thomas') {
+    return whittakerByThomas(yData, restOptions);
+  }
+
+  return whittakerByCholesky(yData, restOptions);
+}
+
+/**
+ * @deprecated Use xWhittakerSmoother instead.
+ * TODO: Remove in next major version.
+ */
+export const xWhitakerSmoother = xWhittakerSmoother;
 
 /**
  * Computes the baseline points for the given data using an iterative smoothing algorithm.
@@ -43,7 +74,7 @@ export interface XWhittakerSmootherOptions extends CalculateAdaptiveWeightsOptio
  * @param options - The options for baseline computation.
  * @returns - The computed baseline points.
  */
-export function xWhittakerSmoother(
+export function whittakerByCholesky(
   yData: NumberArray,
   options: XWhittakerSmootherOptions = {},
 ) {
@@ -140,8 +171,130 @@ function getWeightsAndControlPoints(
   };
 }
 
-/**
- * @deprecated Use xWhittakerSmoother instead.
- * TODO: Remove in next major version.
- */
-export const xWhitakerSmoother = xWhittakerSmoother;
+function whittakerByThomas(
+  yData: NumberArray,
+  options: XWhittakerSmootherOptions = {},
+) {
+  const {
+    lambda = 100,
+    maxIterations = 100,
+    tolerance = 1e-6,
+    factorStd = 3,
+    learningRate = 0.5,
+  } = options;
+
+  const n = yData.length;
+  const y = xEnsureFloat64(yData);
+  let { controlPoints, weights } = getWeightsAndControlPoints(yData, options);
+
+  const prevBaseline = new Float64Array(n);
+  let baseline = xEnsureFloat64(yData);
+
+  // Precompute base diagonal and constant off-diagonals (−lambda)
+  const baseDiag = new Float64Array(n);
+  if (n === 1) baseDiag[0] = lambda;
+  else {
+    baseDiag[0] = lambda;
+    for (let i = 1; i < n - 1; i++) baseDiag[i] = 2 * lambda;
+    baseDiag[n - 1] = lambda;
+  }
+  const lower = new Float64Array(Math.max(0, n - 1));
+  const upper = new Float64Array(Math.max(0, n - 1));
+  for (let i = 0; i < lower.length; i++) {
+    lower[i] = -lambda;
+    upper[i] = -lambda;
+  }
+
+  const main = new Float64Array(n);
+  const rhs = new Float64Array(n);
+  const solution = new Float64Array(n);
+  const workC = new Float64Array(Math.max(0, n - 1));
+  const workD = new Float64Array(n);
+
+  let iteration = 0;
+  let delta = Infinity;
+
+  /**
+   * Iterative Whittaker smoothing implementation using the Thomas algorithm
+   * (tridiagonal solver). The method constructs the system
+   * [W + lambda * D'D] z = W * y where D is the second-difference operator
+   * and W are adaptive weights. At each iteration the tridiagonal system is
+   * solved with the Thomas algorithm and the weights are updated using
+   * `calculateAdaptiveWeights` until convergence.
+   *
+   * Use this algorithm by passing `algorithm: 'thomas'` to `xWhittakerSmoother`.
+   * It is more memory-efficient for large inputs because it avoids forming
+   * the full banded matrix, but both implementations aim to produce the same
+   * baseline result.
+   *
+   * @param yData - input signal/spectrum
+   * @param options - smoothing options (supports `lambda`, `maxIterations`,
+   *                  `tolerance`, `factorStd`, `learningRate`, and optional
+   *                  `controlPoints` / `weights` inherited from
+   *                  `CalculateAdaptiveWeightsOptions`).
+   * @returns baseline as a `Float64Array`.
+   */
+
+  while (iteration < maxIterations && delta > tolerance) {
+    // Build main diagonal = baseDiag + weights, and RHS = weights * y
+    for (let i = 0; i < n; i++) {
+      main[i] = baseDiag[i] + weights[i];
+      rhs[i] = weights[i] * y[i];
+    }
+
+    // Solve tridiagonal system in-place into `solution`
+    solveTridiagonalFloat64(lower, main, upper, rhs, solution, workC, workD);
+
+    weights = calculateAdaptiveWeights(y, solution, weights, {
+      controlPoints,
+      learningRate,
+      factorStd,
+    });
+
+    delta = calculateDelta(solution, prevBaseline, n);
+    prevBaseline.set(solution);
+    baseline = xEnsureFloat64(solution);
+    iteration++;
+  }
+
+  return baseline;
+}
+
+function solveTridiagonalFloat64(
+  lower: Float64Array,
+  diag: Float64Array,
+  upper: Float64Array,
+  rhs: Float64Array,
+  out?: Float64Array,
+  cp?: Float64Array,
+  dp?: Float64Array,
+): Float64Array {
+  const n = diag.length;
+  const x = out ?? new Float64Array(n);
+  if (n === 0) return x;
+  if (n === 1) {
+    x[0] = rhs[0] / diag[0];
+    return x;
+  }
+  const cprime = cp ?? new Float64Array(n - 1);
+  const dprime = dp ?? new Float64Array(n);
+
+  let denom = diag[0];
+  cprime[0] = upper[0] / denom;
+  dprime[0] = rhs[0] / denom;
+
+  for (let i = 1; i < n - 1; i++) {
+    denom = diag[i] - lower[i - 1] * cprime[i - 1];
+    cprime[i] = upper[i] / denom;
+    dprime[i] = (rhs[i] - lower[i - 1] * dprime[i - 1]) / denom;
+  }
+
+  denom = diag[n - 1] - lower[n - 2] * cprime[n - 2];
+  dprime[n - 1] = (rhs[n - 1] - lower[n - 2] * dprime[n - 2]) / denom;
+
+  x[n - 1] = dprime[n - 1];
+  for (let i = n - 2; i >= 0; i--) {
+    x[i] = dprime[i] - cprime[i] * x[i + 1];
+  }
+  return x;
+}

--- a/src/x/xWhittakerSmoother.ts
+++ b/src/x/xWhittakerSmoother.ts
@@ -43,7 +43,7 @@ export interface XWhittakerSmootherOptions extends CalculateAdaptiveWeightsOptio
    * - `'thomas'` — use a tridiagonal formulation and solve with the Thomas
    *   algorithm (specialised tridiagonal solver). Lower memory usage and
    *   faster for large inputs when the system is tridiagonal.
-   * @default 'cholesky'
+   * @default 'thomas'
    */
   algorithm?: 'cholesky' | 'thomas';
 }
@@ -52,7 +52,7 @@ export function xWhittakerSmoother(
   yData: NumberArray,
   options: XWhittakerSmootherOptions = {},
 ) {
-  const { algorithm = 'cholesky', ...restOptions } = options;
+  const { algorithm = 'thomas', ...restOptions } = options;
 
   if (algorithm === 'thomas') {
     return whittakerByThomas(yData, restOptions);
@@ -87,7 +87,6 @@ function whittakerByCholesky(
 
   const size = yData.length;
 
-  // eslint-disable-next-line prefer-const
   const { controlPoints, weights } = getWeightsAndControlPoints(yData, options);
   const prevBaseline: Float64Array = new Float64Array(size);
 

--- a/src/x/xWhittakerSmoother.ts
+++ b/src/x/xWhittakerSmoother.ts
@@ -43,8 +43,7 @@ export interface XWhittakerSmootherOptions extends CalculateAdaptiveWeightsOptio
    * - `'thomas'` — use a tridiagonal formulation and solve with the Thomas
    *   algorithm (specialised tridiagonal solver). Lower memory usage and
    *   faster for large inputs when the system is tridiagonal.
-   *
-   * Default: `'cholesky'`.
+   * @default 'cholesky'
    */
   algorithm?: 'cholesky' | 'thomas';
 }
@@ -74,7 +73,7 @@ export const xWhitakerSmoother = xWhittakerSmoother;
  * @param options - The options for baseline computation.
  * @returns - The computed baseline points.
  */
-export function whittakerByCholesky(
+function whittakerByCholesky(
   yData: NumberArray,
   options: XWhittakerSmootherOptions = {},
 ) {
@@ -89,13 +88,14 @@ export function whittakerByCholesky(
   const size = yData.length;
 
   // eslint-disable-next-line prefer-const
-  let { controlPoints, weights } = getWeightsAndControlPoints(yData, options);
+  const { controlPoints, weights } = getWeightsAndControlPoints(yData, options);
   const prevBaseline: Float64Array = new Float64Array(size);
 
   let iteration = 0;
   let delta = Infinity;
   let baseline = xEnsureFloat64(yData);
-  const upperTriangularNonZeros = createSystemMatrix(size, lambda);
+  const { upperTriangularNonZeros, permutationEncodedArray } =
+    createSystemMatrix(size, lambda);
   while (iteration < maxIterations && delta > tolerance) {
     const { leftHandSide, rightHandSide } = addWeights(
       upperTriangularNonZeros,
@@ -103,7 +103,11 @@ export function whittakerByCholesky(
       weights,
     );
 
-    const cho = matrixCholeskySolver(leftHandSide, size);
+    const cho = matrixCholeskySolver(
+      leftHandSide,
+      size,
+      permutationEncodedArray,
+    );
 
     if (!cho) {
       return baseline;
@@ -111,7 +115,8 @@ export function whittakerByCholesky(
 
     const newBaseline = cho(rightHandSide);
 
-    weights = calculateAdaptiveWeights(yData, newBaseline, weights, {
+    //weights is updated inplace
+    calculateAdaptiveWeights(yData, newBaseline, weights, {
       controlPoints,
       learningRate,
       factorStd,
@@ -185,15 +190,16 @@ function whittakerByThomas(
 
   const n = yData.length;
   const y = xEnsureFloat64(yData);
-  let { controlPoints, weights } = getWeightsAndControlPoints(yData, options);
+  const { controlPoints, weights } = getWeightsAndControlPoints(yData, options);
 
   const prevBaseline = new Float64Array(n);
   let baseline = xEnsureFloat64(yData);
 
   // Precompute base diagonal and constant off-diagonals (−lambda)
   const baseDiag = new Float64Array(n);
-  if (n === 1) baseDiag[0] = lambda;
-  else {
+  if (n === 1) {
+    baseDiag[0] = lambda;
+  } else {
     baseDiag[0] = lambda;
     for (let i = 1; i < n - 1; i++) baseDiag[i] = 2 * lambda;
     baseDiag[n - 1] = lambda;
@@ -226,7 +232,6 @@ function whittakerByThomas(
    * It is more memory-efficient for large inputs because it avoids forming
    * the full banded matrix, but both implementations aim to produce the same
    * baseline result.
-   *
    * @param yData - input signal/spectrum
    * @param options - smoothing options (supports `lambda`, `maxIterations`,
    *                  `tolerance`, `factorStd`, `learningRate`, and optional
@@ -245,7 +250,7 @@ function whittakerByThomas(
     // Solve tridiagonal system in-place into `solution`
     solveTridiagonalFloat64(lower, main, upper, rhs, solution, workC, workD);
 
-    weights = calculateAdaptiveWeights(y, solution, weights, {
+    calculateAdaptiveWeights(y, solution, weights, {
       controlPoints,
       learningRate,
       factorStd,


### PR DESCRIPTION
uses cuthillmckee permutation in xwhittakersmoother (it improve speed in around 3x faster)
implement Thomas algorithm to solve tridiagonal systems like Q = W + λ D'D
keep cholesky method by add a new option in xWhittakerSmoother `algorithm: 'cholesky' | 'thomas'. by default the function uses Thomas method because currently it is used for big arrays.