### PR TITLE
fix: correct xMaxAbsoluteValue sign and guard numeric edge cases

### DIFF
--- a/src/x/__tests__/xMaxAbsoluteValue.test.ts
+++ b/src/x/__tests__/xMaxAbsoluteValue.test.ts
@@ -20,4 +20,10 @@ test('xMaxAbsoluteValue', () => {
   expect(xMaxAbsoluteValue([3, 2, 1], { toIndex: 1 })).toBe(3);
   expect(xMaxAbsoluteValue([1, 2, 3], { fromIndex: 1, toIndex: 1 })).toBe(2);
   expect(xMaxAbsoluteValue([3, 2, 1], { fromIndex: 1, toIndex: 1 })).toBe(2);
+
+  // a negative largest-magnitude element must be absolutized, including at index 0
+  expect(xMaxAbsoluteValue([-5])).toBe(5);
+  expect(xMaxAbsoluteValue([-5, -3])).toBe(5);
+  expect(xMaxAbsoluteValue([-5, -3, -4])).toBe(5);
+  expect(xMaxAbsoluteValue([-5, 2, 3])).toBe(5);
 });

--- a/src/x/__tests__/xSampling.test.ts
+++ b/src/x/__tests__/xSampling.test.ts
@@ -9,6 +9,13 @@ test('testing on array', () => {
   expect(result).toStrictEqual(Float64Array.from([0, 4, 8]));
 });
 
+test('length of 1 returns the first element', () => {
+  const array = [0, 1, 2, 3, 4, 5, 6, 7, 8];
+  const result = xSampling(array, { length: 1 });
+
+  expect(result).toStrictEqual(Float64Array.from([0]));
+});
+
 test('testing same length', () => {
   const array = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
   const result = xSampling(array);

--- a/src/x/__tests__/xSequentialFillFromTo.test.ts
+++ b/src/x/__tests__/xSequentialFillFromTo.test.ts
@@ -8,6 +8,12 @@ test('Default array type (Float64Array)', () => {
   expect(result).toStrictEqual(new Float64Array([0, 2, 4, 6, 8, 10]));
 });
 
+test('size of 1 returns from', () => {
+  const result = xSequentialFillFromTo({ from: 10, to: 20, size: 1 });
+
+  expect(result).toStrictEqual(new Float64Array([10]));
+});
+
 test('Int32Array', () => {
   const result = xSequentialFillFromTo(
     { from: 0, to: 10, size: 6 },

--- a/src/x/xApplyFunctionStr.ts
+++ b/src/x/xApplyFunctionStr.ts
@@ -39,7 +39,7 @@ export function xApplyFunctionStr(
       )
       .replaceAll('Math.Math', 'Math')})`,
   );
-  const toReturn = Float64Array.from(array);
+  const toReturn = new Float64Array(array.length);
   for (let i = 0; i < array.length; i++) {
     toReturn[i] = fct(array[i]);
     if (Number.isNaN(toReturn[i])) {

--- a/src/x/xDotProduct.ts
+++ b/src/x/xDotProduct.ts
@@ -1,6 +1,6 @@
 import type { NumberArray } from 'cheminfo-types';
 
-import { xMultiply } from './xMultiply.ts';
+import { xCheckLengths } from './xCheckLengths.ts';
 
 /**
  * Dot product between two arrays.
@@ -8,10 +8,10 @@ import { xMultiply } from './xMultiply.ts';
  * @param B - second array.
  */
 export function xDotProduct(A: NumberArray, B: NumberArray): number {
-  const g = xMultiply(A, B);
+  xCheckLengths(A, B);
   let result = 0;
   for (let i = 0; i < A.length; i++) {
-    result += g[i];
+    result += A[i] * B[i];
   }
   return result;
 }

--- a/src/x/xMaxAbsoluteValue.ts
+++ b/src/x/xMaxAbsoluteValue.ts
@@ -15,7 +15,7 @@ export function xMaxAbsoluteValue(
 ): number {
   xCheck(array);
   const { fromIndex, toIndex } = xGetFromToIndex(array, options);
-  let maxValue = array[fromIndex];
+  let maxValue = Math.abs(array[fromIndex]);
 
   for (let i = fromIndex + 1; i <= toIndex; i++) {
     if (array[i] >= 0) {

--- a/src/x/xSampling.ts
+++ b/src/x/xSampling.ts
@@ -44,7 +44,7 @@ function downSampling(
   length: number,
 ): Float64Array<ArrayBuffer> {
   const returnArray = new Float64Array(length);
-  const delta = (array.length - 1) / (length - 1);
+  const delta = length === 1 ? 0 : (array.length - 1) / (length - 1);
 
   for (let i = 0; i < length; i++) {
     returnArray[i] = array[Math.round(i * delta)];

--- a/src/x/xSequentialFillFromTo.ts
+++ b/src/x/xSequentialFillFromTo.ts
@@ -28,6 +28,6 @@ export function xSequentialFillFromTo<
   options: XSequentialFillFromToOptions<ArrayConstructorType> = {},
 ): NumberArrayType<ArrayConstructorType> {
   const { from, to, size } = parameters;
-  const step = (to - from) / (size - 1);
+  const step = size <= 1 ? 0 : (to - from) / (size - 1);
   return xSequentialFillFromStep({ from, step, size }, options);
 }


### PR DESCRIPTION
Audit of the `x/` helpers surfaced one real bug and several edge cases.

**Bugs**
- `xMaxAbsoluteValue` seeded its accumulator with the raw first element instead of `Math.abs`, so a negative largest-magnitude value (incl. at index 0) was wrong — e.g. `[-5, -3]` returned `3`.
- `xSequentialFillFromTo({ size: 1 })` and `xSampling(array, { length: 1 })` divided by zero and returned `[NaN]`; they now return `[from]` / the first element.

**Perf**
- `xDotProduct` no longer allocates an intermediate array via `xMultiply` — single zero-allocation loop.
- `xApplyFunctionStr` allocates the output instead of copying values that are immediately overwritten.

Regression tests added for each bug.