### PR TITLE
chore: revert release 14.29.3 to regenerate it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,19 +1,5 @@
 # Changelog
 
-## [14.29.3](https://github.com/mljs/spectra-processing/compare/v14.29.2...v14.29.3) (2026-07-17)
-
-
-### Bug Fixes
-
-* correct xMaxAbsoluteValue sign and guard numeric edge cases ([#383](https://github.com/mljs/spectra-processing/issues/383)) ([1b2ddd0](https://github.com/mljs/spectra-processing/commit/1b2ddd054ba2868c98ca9a1eefc833eea176c4a1))
-* reject NaN and speed up box plot distribution stats ([#382](https://github.com/mljs/spectra-processing/issues/382)) ([289ff10](https://github.com/mljs/spectra-processing/commit/289ff105771d49a7887d4cf4ed8ea0a99dc9ea4c))
-* xNoiseSanPlot refined negative noise read from wrong array ([#386](https://github.com/mljs/spectra-processing/issues/386)) ([9ae3772](https://github.com/mljs/spectra-processing/commit/9ae377278ec7cd81757d0e2d15ddffd81494298f))
-
-
-### Performance Improvements
-
-* avoid extra array copies in xy median and scan helpers ([#385](https://github.com/mljs/spectra-processing/issues/385)) ([b068dcb](https://github.com/mljs/spectra-processing/commit/b068dcb39118c2bc4b78cf67f7e665ffa8eb7d88))
-
 ## [14.29.2](https://github.com/mljs/spectra-processing/compare/v14.29.1...v14.29.2) (2026-07-03)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ml-spectra-processing",
-  "version": "14.29.3",
+  "version": "14.29.2",
   "license": "MIT",
   "description": "Various method to process spectra",
   "keywords": [],


### PR DESCRIPTION
14.29.3 was created by a rebase race — its changelog missed the xyEqualIntegrationVector / xEqualIntegrationVectorSimilarity feat and it never published to npm (latest is 14.29.2). Reverting so release-please regenerates a correct 14.30.0 that includes the feature.